### PR TITLE
use fixed version in dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ authors = ["Carl Lerche <me@carllerche.com>", "Armin Ronacher <armin.ronacher@ac
 log = "0.3.6"
 futures = "0.1"
 tokio-core = "0.1"
-tokio-proto = { git = "https://github.com/tokio-rs/tokio-proto" }
-tokio-service = { git = "https://github.com/tokio-rs/tokio-service" }
+tokio-proto = "0.1"
+tokio-service = "0.1"
 
 [dev-dependencies]
 env_logger = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,6 @@ struct RedisProto;
 impl<T: Io + 'static> ClientProto<T> for RedisProto {
     type Request = Cmd;
     type Response = Value;
-    type Error = io::Error;
     type Transport = RedisTransport<T>;
     type BindTransport = io::Result<Self::Transport>;
 


### PR DESCRIPTION
`tokio-proto` and `tokio-service` have changed their API so it no longer compiles, this PR uses published version to make sure it compiles. 