### PR TITLE
Remove deprecated / build warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Carl Lerche <me@carllerche.com>", "Armin Ronacher <armin.ronacher@ac
 log = "0.3.6"
 futures = "0.1"
 tokio-core = "0.1"
+tokio-io = "0.1"
 tokio-proto = "0.1"
 tokio-service = "0.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 extern crate futures;
 extern crate tokio_core;
+extern crate tokio_io;
 extern crate tokio_proto;
 extern crate tokio_service;
 
@@ -19,9 +20,9 @@ use std::io;
 use std::net::SocketAddr;
 
 use futures::{Async, Future};
-use tokio_core::io::Io;
 use tokio_core::net::TcpStream;
 use tokio_core::reactor::Handle;
+use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_proto::TcpClient;
 use tokio_proto::pipeline::{ClientProto, ClientService};
 use tokio_service::Service;
@@ -59,7 +60,7 @@ pub type Response = Box<Future<Item = Value, Error = io::Error>>;
 
 struct RedisProto;
 
-impl<T: Io + 'static> ClientProto<T> for RedisProto {
+impl<T: AsyncRead + AsyncWrite + 'static> ClientProto<T> for RedisProto {
     type Request = Cmd;
     type Response = Value;
     type Transport = RedisTransport<T>;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -110,7 +110,7 @@ impl<'a, T: Read> Parser<T> {
                 Ok(nread) if nread > 0 =>
                     i += nread,
                 Ok(_) =>
-                    return fail!((ErrorKind::ResponseError, "Could not read enough bytes")),
+                    fail!((ErrorKind::ResponseError, "Could not read enough bytes")),
                 Err(e) =>
                     return Err(From::from(e))
             }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,7 +1,7 @@
 use {Cmd, Value};
 use parser::Parser;
 use types::RedisError;
-use tokio_core::io::Io;
+use tokio_io::{AsyncRead, AsyncWrite};
 use futures::{Async, AsyncSink, Poll, Stream, Sink, StartSend};
 use std::mem;
 use std::io::{self, Cursor};
@@ -26,7 +26,7 @@ struct RedisProto;
 // pub type RespFrame = Frame<Value, (), RedisError>;
 
 impl<T> RedisTransport<T>
-    where T: Io,
+    where T: AsyncRead + AsyncWrite,
 {
     pub fn new(inner: T) -> RedisTransport<T> {
         RedisTransport {
@@ -40,7 +40,7 @@ impl<T> RedisTransport<T>
 }
 
 impl<T> RedisTransport<T>
-    where T: Io,
+    where T: AsyncRead + AsyncWrite,
 {
     fn wr_is_empty(&self) -> bool {
         self.wr_remaining() == 0
@@ -88,7 +88,7 @@ impl<T> RedisTransport<T>
 }
 
 impl<T> Stream for RedisTransport<T>
-    where T: Io,
+    where T: AsyncRead + AsyncWrite,
 {
     type Item = Value;
     type Error = io::Error;
@@ -145,7 +145,7 @@ impl<T> Stream for RedisTransport<T>
 }
 
 impl<T> Sink for RedisTransport<T>
-    where T: Io,
+    where T: AsyncRead + AsyncWrite,
 {
     type SinkItem = Cmd;
     type SinkError = io::Error;


### PR DESCRIPTION
Switch from using deprecated `tokio_core::io` to `tokio_io`, and clean up the code so tokio-redis compiles without build warnings.